### PR TITLE
update datahandling 

### DIFF
--- a/cqed/utils/datahandling.py
+++ b/cqed/utils/datahandling.py
@@ -41,7 +41,7 @@ def db_to_xarray(ind, **kwargs):
     d = load_by_run_spec(captured_run_id=ind, **kwargs)
     _df = []
     for obj in d.dependent_parameters:
-        _df += [d.get_data_as_pandas_dataframe()[obj.name].to_xarray()]
+        _df += [d.to_pandas_dataframe_dict()[obj.name].to_xarray()]
 
     ds = merge([*_df])
     ds.attrs['snapshot'] = d.snapshot

--- a/cqed/utils/datahandling.py
+++ b/cqed/utils/datahandling.py
@@ -41,23 +41,6 @@ def db_to_xarray(ind, **kwargs):
      and the dependent parameters as Data variables
     """
 
-    warnings.warn("The function <db_to_xarray> is deprecated, because this method will be removed due to "
-                  "duplication with a existing build-in function from qcodes. "
-                  "Please use 'load_by_run_spec(captured_run_id=ind, **kwarg)' and 'to_xarray_dataset()' instead.",
-                  category=DeprecationWarning, stacklevel=2)
-
     d = load_by_run_spec(captured_run_id=ind, **kwargs)
-    _df = []
-    for obj in d.dependent_parameters:
-        _df += [d.to_pandas_dataframe_dict()[obj.name].to_xarray()]
-
-    ds = merge([*_df])
-    ds.attrs['snapshot'] = d.snapshot
-    ds.attrs['exp_name'] = d.exp_name
-    ds.attrs['captured_run_id'] = d.captured_run_id
-    ds.attrs['sample_name'] = d.sample_name
-    ds.attrs['guid'] = d.guid
-    ds.attrs['run_timestamp_raw'] = d.run_timestamp_raw
-    ds.attrs['completed_timestamp_raw'] = d.completed_timestamp_raw
-
+    ds = d.to_xarray_dataset()
     return ds

--- a/cqed/utils/datahandling.py
+++ b/cqed/utils/datahandling.py
@@ -2,6 +2,8 @@ from pathlib import Path
 from qcodes import initialise_or_create_database_at, config, load_by_run_spec
 from xarray import merge
 
+import warnings
+
 
 def create_local_dbase_in(folder_name='general', db_name='experiments.db', data_dir='D:/Data'):
     """    
@@ -26,6 +28,7 @@ def create_local_dbase_in(folder_name='general', db_name='experiments.db', data_
 
 
 def db_to_xarray(ind, **kwargs):
+
     """
     Take a dataset from a qcodes database identified by its ID and transform it into a xarray.Dataset
     Wraps around the function load_by_run_spec, which allows to get data from different databases, if you supply
@@ -37,6 +40,11 @@ def db_to_xarray(ind, **kwargs):
     @return: xarray.Dataset with the independent parameters as coordinates,
      and the dependent parameters as Data variables
     """
+
+    warnings.warn("The function <db_to_xarray> is deprecated, because this method will be removed due to "
+                  "duplication with a existing build-in function from qcodes. "
+                  "Please use 'load_by_run_spec(captured_run_id=ind, **kwarg)' and 'to_xarray_dataset()' instead.",
+                  category=DeprecationWarning, stacklevel=2)
 
     d = load_by_run_spec(captured_run_id=ind, **kwargs)
     _df = []


### PR DESCRIPTION
The function <get_data_as_pandas_dataframe> is deprecated, because this method will be removed due to inconcise naming, I renamed the method to_pandas_dataframe_dict. Thus I use "to_pandas_dataframe_dict" as an alternative.

Please check pull request from my fork to base repo master branch @LGruenhaupt @abargerbos 